### PR TITLE
Port to MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Build Requirements
 Building PostgresAdapter requires a number of dependencies. In addition to a C/C++ dev
 environment, the following modules are needed, which can be installed via conda:
 
-* NumPy
+* NumPy 1.11
 * Pandas
 * postgresql 0.9.3 (C lib)
 

--- a/buildscripts/condarecipe/meta.yaml
+++ b/buildscripts/condarecipe/meta.yaml
@@ -11,13 +11,14 @@ build:
 requirements:
   build:
     - python 
-    - numpy
+    - numpy 1.11*
     - cython
     - postgresql
+    - psycopg2
 
   run:
     - python 
-    - numpy
+    - numpy 1.11*
     - pandas
     - six
     - ordereddict     [py26]
@@ -28,7 +29,6 @@ test:
     - nose
     - pytest
     - sqlalchemy
-    - psycopg2
 
   imports:
     - postgresadapter

--- a/buildscripts/condarecipe/run_test.py
+++ b/buildscripts/condarecipe/run_test.py
@@ -2,36 +2,56 @@ import subprocess
 import postgresadapter
 import os
 import time
-import inspect
+import atexit
+import sys
+import shlex
 from postgresadapter.tests import setup_postgresql_data
 
 
 
-def start_postgres(waitsecs=10):
-    subprocess.check_call('docker run --name postgres-db --publish 5432:5432 -d mdillon/postgis:9.5-alpine', shell=True)
-    print('Waiting {} secs for PostgreSQL database to start up...'.format(waitsecs))
-    time.sleep(waitsecs)
+def start_postgres():
+    print('Starting PostgreSQL server...')
+
+    cmd = shlex.split('docker run --name postgres-db --publish 5432:5432 mdillon/postgis:9.5-alpine')
+    proc = subprocess.Popen(cmd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                            universal_newlines=True)
+
+    pg_init = False
+    while True:
+        output_line = proc.stdout.readline()
+        print(output_line.rstrip())
+        if proc.poll() is not None: # If the process exited
+            raise Exception('PostgreSQL server failed to start up properly.')
+        if 'PostgreSQL init process complete; ready for start up' in output_line:
+            pg_init = True
+        elif pg_init and 'database system is ready to accept connections' in output_line:
+            break
 
 
 def stop_postgres(let_fail=False):
     try:
+        print('Stopping PostgreSQL server...')
         subprocess.check_call('docker ps -q --filter "name=postgres-db" | xargs docker rm -vf', shell=True)
     except subprocess.CalledProcessError:
         if not let_fail:
             raise
 
 
-### Run PostgreSQL tests
+### Start PostgreSQL
 stop_postgres(let_fail=True)
-start_postgres(waitsecs=10)
-exec(inspect.getsource(setup_postgresql_data))
+start_postgres()
+atexit.register(stop_postgres)
+
+### Run PostgresAdapter tests
+setup_postgresql_data.main()
 assert postgresadapter.test()
 
 ### Run PostGIS tests
-#stop_postgres()
-#start_postgres(waitsecs=10)
 assert postgresadapter.test_postgis()
-stop_postgres()
 
 # Print the version
 print('postgresadapter.__version__: %s' % postgresadapter.__version__)
+
+sys.exit(0)

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: postgresadapter
 dependencies:
 - ipython
-- numpy
+- numpy =1.11
 - pandas
 - pytest
 - cython

--- a/postgresadapter/tests/setup_postgresql_data.py
+++ b/postgresadapter/tests/setup_postgresql_data.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 import logging
 import string
 import numpy as np
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 CASTS_TEST_NUM_RECORDS = 23456
 
-if __name__ == '__main__':
+def main():
     conn = psycopg2.connect(host='localhost',
                             dbname='postgres',
                             user='postgres',
@@ -183,3 +184,9 @@ if __name__ == '__main__':
     conn.commit()
     cursor.close()
     conn.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
- Get conda-build and all unit tests passing for MacOS
- Make the test runner a bit more robust by monitoring output until the database is up (instead of sleeping)