### PR TITLE
Forward PG_PORT to an arbitrary local port during testing

### DIFF
--- a/buildscripts/condarecipe/run_test.py
+++ b/buildscripts/condarecipe/run_test.py
@@ -10,30 +10,57 @@ from postgresadapter.tests import setup_postgresql_data
 
 
 def start_postgres():
+    """Bring up a container running PostgreSQL with PostGIS. Pipe the output of
+    the container process to stdout, until the database is ready to accept
+    connections. This container may be stopped with ``stop_postgres()``.
+
+    Returns the local port as a string.
+    """
     print('Starting PostgreSQL server...')
 
-    cmd = shlex.split('docker run --name postgres-db --publish 5432:5432 mdillon/postgis:9.5-alpine')
+    # More options here: https://github.com/appropriate/docker-postgis
+    cmd = shlex.split('docker run --rm --name pgadapter-postgres --publish 5432 '
+                      'mdillon/postgis:9.4-alpine')
     proc = subprocess.Popen(cmd,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT,
                             universal_newlines=True)
 
+    # The database may have been restarted in the container, so track whether
+    # initialization happened or not.
     pg_init = False
     while True:
         output_line = proc.stdout.readline()
         print(output_line.rstrip())
-        if proc.poll() is not None: # If the process exited
+        # If the process exited, raise exception.
+        if proc.poll() is not None:
             raise Exception('PostgreSQL server failed to start up properly.')
-        if 'PostgreSQL init process complete; ready for start up' in output_line:
+        # Detect when initialization has happened, so we can stop waiting when
+        # the database is accepting connections.
+        if ('PostgreSQL init process complete; '
+                'ready for start up') in output_line:
             pg_init = True
-        elif pg_init and 'database system is ready to accept connections' in output_line:
+        elif (pg_init and
+              'database system is ready to accept connections' in output_line):
             break
+
+    # Print the local port to which Docker mapped Postgres
+    cmd = shlex.split('docker ps --filter "name=pgadapter-postgres" --format '
+                      '"{{ .Ports }}"')
+    port_map = subprocess.check_output(cmd, universal_newlines=True).strip()
+    port = port_map.split('->', 1)[0].split(':', 1)[1]
+    return port
 
 
 def stop_postgres(let_fail=False):
+    """Attempt to shut down the container started by ``start_postgres()``.
+    Raise an exception if this operation fails, unless ``let_fail``
+    evaluates to True.
+    """
     try:
         print('Stopping PostgreSQL server...')
-        subprocess.check_call('docker ps -q --filter "name=postgres-db" | xargs docker rm -vf', shell=True)
+        subprocess.check_call('docker ps -q --filter "name=pgadapter-postgres" | '
+                              'xargs docker rm -vf', shell=True)
     except subprocess.CalledProcessError:
         if not let_fail:
             raise
@@ -41,15 +68,15 @@ def stop_postgres(let_fail=False):
 
 ### Start PostgreSQL
 stop_postgres(let_fail=True)
-start_postgres()
+local_port = start_postgres()
 atexit.register(stop_postgres)
 
 ### Run PostgresAdapter tests
-setup_postgresql_data.main()
-assert postgresadapter.test()
+setup_postgresql_data.main(port=local_port)
+assert postgresadapter.test(port=local_port)
 
 ### Run PostGIS tests
-assert postgresadapter.test_postgis()
+assert postgresadapter.test_postgis(port=local_port)
 
 # Print the version
 print('postgresadapter.__version__: %s' % postgresadapter.__version__)

--- a/postgresadapter/__init__.py
+++ b/postgresadapter/__init__.py
@@ -24,7 +24,7 @@ from postgresadapter.lib.errors import (AdapterException, AdapterIndexError,
                                     ParserError, SourceError, SourceNotFoundError)
 
 
-def test(host='localhost', dbname='postgres', user='postgres', verbose=True):
+def test(host='localhost', dbname='postgres', user='postgres', port='5432', verbose=True):
     test_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tests')        
     postgres_test_script = 'test_PostgresAdapter.py'
     args = []
@@ -32,6 +32,7 @@ def test(host='localhost', dbname='postgres', user='postgres', verbose=True):
     args.append('--pg_host {0}'.format(host))
     args.append('--pg_dbname {0}'.format(dbname))
     args.append('--pg_user {0}'.format(user))
+    args.append('--pg_port {0}'.format(port))
     if verbose:
         args.append('-v')
 
@@ -42,11 +43,12 @@ def test(host='localhost', dbname='postgres', user='postgres', verbose=True):
     return False
 
 
-def test_postgis(host='localhost', dbname='postgres', user='postgres', verbose=True):
+def test_postgis(host='localhost', dbname='postgres', user='postgres', port='5432', verbose=True):
     test_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'tests')        
     postgis_test_script = 'test_PostGIS.py'
     args = []
     args.append(os.path.join(test_dir, postgis_test_script))
+    args.append('--pg_port {0}'.format(port))
     if verbose:
         args.append('-v')
 

--- a/postgresadapter/tests/conftest.py
+++ b/postgresadapter/tests/conftest.py
@@ -4,6 +4,7 @@ def pytest_addoption(parser):
     parser.addoption('--pg_host', action='store')
     parser.addoption('--pg_dbname', action='store')
     parser.addoption('--pg_user', action='store')
+    parser.addoption('--pg_port', action='store')
     parser.addoption('--acc_host', action='store')
     parser.addoption('--acc_user', action='store')
     parser.addoption('--acc_password', action='store')

--- a/postgresadapter/tests/setup_postgresql_data.py
+++ b/postgresadapter/tests/setup_postgresql_data.py
@@ -12,10 +12,11 @@ logger = logging.getLogger(__name__)
 
 CASTS_TEST_NUM_RECORDS = 23456
 
-def main():
+def main(port='5432'):
     conn = psycopg2.connect(host='localhost',
                             dbname='postgres',
-                            user='postgres')
+                            user='postgres',
+                            port=port)
     conn.set_isolation_level(0)
     cursor = conn.cursor()
     logger.debug('Creating database "unit_tests"...')
@@ -25,7 +26,8 @@ def main():
 
     conn = psycopg2.connect(host='localhost',
                             dbname='postgres', #unit_tests',
-                            user='postgres')
+                            user='postgres',
+                            port=port)
 
     cursor = conn.cursor()
     logger.debug('Installing postgis extensions if necessary...')

--- a/postgresadapter/tests/test_PostGIS.py
+++ b/postgresadapter/tests/test_PostGIS.py
@@ -9,9 +9,16 @@ import psycopg2
 import string
 import pytest
 
+
+@pytest.fixture(scope='class')
+def pg_config(request):
+    """Set the postgresql_url attribute on TestCase classes."""
+    request.cls.postgresql_url = 'postgresql://postgres@localhost:{}/postgres'.format(request.config.option.pg_port)
+
+
+@pytest.mark.usefixtures('pg_config')
 class TestPostGIS(unittest.TestCase):
     def setUp(self):
-        self.postgresql_url = 'postgresql://postgres@localhost:5432/postgres'
         engine = sqlalchemy.create_engine(self.postgresql_url)
         self.conn = engine.connect()
 

--- a/postgresadapter/tests/test_PostgresAdapter.py
+++ b/postgresadapter/tests/test_PostgresAdapter.py
@@ -17,17 +17,19 @@ def postgres(request):
 
     class Dummy(object):
 
-        def __init__(self, host, dbname, user):
+        def __init__(self, host, dbname, user, port):
             self.host = host
             self.dbname = dbname
             self.user = user
+            self.port = port
 
         def url(self):
-            return 'host={0} dbname={1} user={2}'.format(self.host, self.dbname, self.user)
+            return 'host={0} dbname={1} user={2} port={3}'.format(self.host, self.dbname, self.user, self.port)
 
     postgresql = Dummy(request.config.option.pg_host,
                        request.config.option.pg_dbname,
-                       request.config.option.pg_user)
+                       request.config.option.pg_user,
+                       request.config.option.pg_port)
     return postgresql
 
 def test_connection(postgres):


### PR DESCRIPTION
This works around a Travis-CI issue in a downstream repo. The downstream repo is failing to build the postgresadapter conda package, because port 5432 is already being used by Travis-CI's pre-installed instance of PostgreSQL. Shutting down the pre-installed instance no longer seems to work as expected.